### PR TITLE
Add CODEOWNERS file for PENG team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+# CODEOWNERS file for repository ownership\n# Generated automatically based on metadata.yml\n\n* @Sixt/PENG\n


### PR DESCRIPTION
## Add CODEOWNERS file for Enhanced Repository Security

Hi team! 👋

This PR adds a CODEOWNERS file to ensure proper code review coverage for your repository.

### What's Changed
- ✅ Added `CODEOWNERS` file with `@Sixt/PENG` as the owner
- ✅ All future PRs will require approval from your team

### Why This Matters
- 🔒 **Enhanced Security**: Ensures code changes are reviewed by the right people
- 📋 **Compliance**: Meets our repository security standards
- 🚀 **Better Collaboration**: Clear ownership and responsibility

### Next Steps
1. **Review this PR** - Make sure the team assignment is correct
2. **Merge when ready** - This will activate the CODEOWNERS protection
3. **Questions?** - Reach out to the Security Engineering team

### Need Help?
- **Security Automations Engineering Team**: [#team_securityengineering](https://e-sixt.slack.com/archives/team_securityengineering)
- **Contact**: harsha.jayarama@sixt.com
- **Repository Status & Tracking**: [GitHub Repos Status](https://sixt-cloud.atlassian.net/wiki/spaces/GOSRE/pages/86848126/GITHUB+REPOS+STATUS)
- **Documentation**: [CODEOWNERS Documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)

---
*This PR was created automatically as part of our repository security compliance initiative.*
