### PR TITLE
Add CODEOWNERS file for PENG team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# CODEOWNERS file for repository ownership
+# Generated automatically based on metadata.yml
+
+* @Sixt/PENG


### PR DESCRIPTION
## Add CODEOWNERS file for Enhanced Repository Security

Hi team!

This PR adds a **CODEOWNERS** file to enforce mandatory code review requirements for your repository, as part of Sixt's ongoing security and compliance initiative.

### What's Changed
- **Added** `.github/CODEOWNERS` file
- **Configured** ownership to `@Sixt/PENG` team  
- **Enforced** mandatory code reviews for all changes

### Why This Matters
This automation is part of our **Branch Protection & Code Review Enhancement** initiative to:
- **Strengthen security** across all repositories
- **Ensure proper code review** by designated team members
- **Maintain compliance** with Sixt development standards
- **Accelerate** your team's review workflow

### Repository Details
- **Team Owner**: `PENG`
- **Data Source**: `metadata.yml`
- **Generated**: 2025-10-14 00:16:37 UTC
- **Target Completion**: Mid-October 2025

### Next Steps
1. **Review** the CODEOWNERS file content below
2. **Verify** your team is correctly assigned
3. **Merge** this PR to activate code review protection
4. **Modify** the file if needed (you can edit directly in this PR)

### Need Help?
- **Security Automations Engineering Team**: [#team_securityengineering](https://e-sixt.slack.com/archives/team_securityengineering)
- **Contact**: harsha.jayarama@sixt.com
- **Repository Status & Tracking**: [GitHub Repos Status](https://sixt-cloud.atlassian.net/wiki/spaces/GOSRE/pages/86848126/GITHUB+REPOS+STATUS)
- **Documentation**: [CODEOWNERS Documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)

### File Preview
```
# CODEOWNERS file for repository ownership
# Generated automatically based on metadata.yml

* @Sixt/PENG
```

---
**Automated by Security Automations Engineering Team**  
*This PR was created by the Repository Compliance Automation System*
